### PR TITLE
Add step about creating folder to readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To install generator-phaser from npm, run:
 $ npm install -g generator-phaser-official
 ```
 
-Finally, initiate the generator:
+Create your folder where you want your game to be located and finally, initiate the generator inside that folder:
 
 ```
 $ yo phaser-official


### PR DESCRIPTION
Add instructions about creating a folder and running `yo phaser-official` command from inside that folder to avoid confusion. I'm not a big Yeoman user so I assumed that `yo phaser-official` would create the project folder for me and then to the scaffolding there. Boy I was wrong and this PR makes this a bit clearer for future users.
